### PR TITLE
Introduce ref and baseline batches

### DIFF
--- a/transport_cut_optimisation/README.md
+++ b/transport_cut_optimisation/README.md
@@ -2,4 +2,24 @@
 
 This directory contains scripts and the example configuration to run the transport cut tuning optimisation.
 
-The only thing that should be necessary, is to change the paths in the various stages to the scripts in the [configuration](config.yaml)
+## Brief overview
+
+The entire optimisation includes the creation of the reference data, followed by the optimisation which is followed by an evaluation stage. To run everything, please follow this README.
+
+
+## Generate the configuration file
+
+The `config.yaml` needs to be generated first. The reason for this is that the reference stage is quite heavy given that steps of all generated events are written out. Therefore, a configuration file is generated with [`generate_config.py`](generate_config.py) as follows
+```bash
+generate_config.py <n_batches> -d <path/to/recipe_dir>
+```
+
+The number of batches means that the reference is repeated that many times so that there are `n_batches x events` available in the end. The number of events can still be tweaked in the generated `path/to/recipe_dir/config.yaml`.
+
+## Run
+
+Done with
+```bash
+python ${O2TUNER}/src/o2tuner/run.py -c <path/to/recipe_dir/config.yaml> -d <workdir>
+```
+

--- a/transport_cut_optimisation/config.yaml.in
+++ b/transport_cut_optimisation/config.yaml.in
@@ -45,12 +45,12 @@ global_config: &global_config
         - HALL
         - PIPE
         - CAVE
-        #- MAG
-        #- DIPO
-        #- ABSO
-        #- SHIL
-        #- FRAME
-        #- COMP
+        - MAG
+        - DIPO
+        - ABSO
+        - SHIL
+        - FRAME
+        - COMP
     parameters_to_optimise: # choose from REPLAY_CUT_PARAMETERS
         - CUTGAM
         - CUTELE
@@ -77,29 +77,7 @@ global_config: &global_config
     baseline_dir: &baseline_dir baseline                        # the baseline directory
 
 
-stages_user:
-    reference_sim: # the reference run
-        python:
-            file: /PATH/TO/o2tunerRecipes/transport_cut_optimisation/reference.py
-            entrypoint: run_reference
-        cwd: *reference_dir
-        config: *global_config
-
-    baseline_sim: # basline run to exclude any RNG effects during hit extraction
-        python:
-            file: /PATH/TO/o2tunerRecipes/transport_cut_optimisation/reference.py
-            entrypoint: run_baseline
-        cwd: *baseline_dir
-        deps:
-            - reference_sim
-        config: *global_config
-
-    baseline_hits: # extract hits for the baseline simulation
-        cmd: "root -l -b -q ${O2_ROOT}/share/macro/analyzeHits.C"
-        log_file: *hits_file
-        deps:
-            - baseline_sim
-        cwd: *baseline_dir
+stages_user: null
 
 stages_optimisation:
     optimisation_genetic_baseline:

--- a/transport_cut_optimisation/evaluate.py
+++ b/transport_cut_optimisation/evaluate.py
@@ -81,7 +81,7 @@ def evaluate(inspectors, config):
         plot_steps_hits_loss(insp, config)
         # at the same time, extract mapping of optuna parameter names to actual meaningful names related to the task at hand
         counter = 0
-        index_to_med_id = parse_yaml(join(resolve_path(config["reference_dir"]), config["index_to_med_id"]))
+        index_to_med_id = parse_yaml(join(resolve_path(f"{config['reference_dir']}_0"), config["index_to_med_id"]))
         for med_id in index_to_med_id:
             for param in config["REPLAY_CUT_PARAMETERS"]:
                 map_params[str(counter)] = f"{param} of {med_id}"

--- a/transport_cut_optimisation/reference.py
+++ b/transport_cut_optimisation/reference.py
@@ -7,52 +7,14 @@ from os.path import join
 from os import environ
 import argparse
 
+import numpy as np
+
 from o2tuner.system import run_command
 from o2tuner.io import parse_json, dump_yaml
 from o2tuner.config import resolve_path
 
 
 MCSTEPLOGGER_ROOT = environ.get("MCSTEPLOGGER_ROOT")
-
-def digest_parameters(path):
-    """
-    Extracts the medium ID - module mapping (seperately for detectors and passive modules).
-    In addition, we get a mapping from an index to a medium ID.
-    Finally, the reference parameters are extracted as a list accorsing to the index mapping.
-    """
-    reference_params = []
-    params = parse_json(path)
-
-    index_to_med_id = []
-    passive_medium_ids_map = {}
-    # pylint: disable=duplicate-code
-    detector_medium_ids_map = {}
-    for module, batches in params.items():
-        if module in ["default", "enableSpecialCuts", "enableSpecialProcesses"]:
-            continue
-
-        for batch in batches:
-            med_id = batch["global_id"]
-            # according to which modules are recognised by this script
-            if module in O2PASSIVE:
-                if module not in passive_medium_ids_map:
-                    passive_medium_ids_map[module] = []
-                passive_medium_ids_map[module].append(med_id)
-            elif module in O2DETECTORS:
-                if module not in detector_medium_ids_map:
-                    detector_medium_ids_map[module] = []
-                detector_medium_ids_map[module].append(med_id)
-            else:
-                continue
-
-            cuts_read = batch.get("cuts", {})
-            cuts_append = [cuts_read.get(rcp, -1.) for rcp in REPLAY_CUT_PARAMETERS]
-
-            index_to_med_id.append(med_id)
-            reference_params.extend(cuts_append)
-
-    return reference_params, index_to_med_id, passive_medium_ids_map, detector_medium_ids_map
-
 
 def run_reference(config):
     """


### PR DESCRIPTION
The final config.yaml must be generated first for a given number of batches. For each batch a reference and baseline is done. The optimisation draws a batch randomly for each trial. The reasoning behind this is that the steplog output is large in general but we might want to optimisae on more than only O(events)=10.